### PR TITLE
Clarity on end screen

### DIFF
--- a/src/neo.rb
+++ b/src/neo.rb
@@ -293,6 +293,8 @@ module Neo
 
     def boring_end_screen
       puts "Mountains are again merely mountains"
+      puts "You have completed the path, but your journey is not over."
+      puts "Go and create, and one day you may become a master."
     end
 
     def artistic_end_screen
@@ -333,6 +335,9 @@ module Neo
                  ,::::::::::::::::              ::,, ,   ,:::,
                       ,::::                         , ,,
                                                   ,,,
+
+            You have completed the path, but your journey is not over.
+               Go and create, and one day you may become a master.
 ENDTEXT
         puts completed
     end
@@ -439,12 +444,12 @@ ENDTEXT
       setup
       begin
         send(name)
-      rescue StandardError, Neo::Sensei::FailedAssertionError => ex
+      rescue Exception => ex
         failed(ex)
       ensure
         begin
           teardown
-        rescue StandardError, Neo::Sensei::FailedAssertionError => ex
+        rescue Exception => ex
           failed(ex) if passed?
         end
       end


### PR DESCRIPTION
When I went through the koans, I saw the end screen many times before I finished because it would show for certain uncaught exceptions, in particular SyntaxError.  
![screenshot from 2015-10-27 15 53 51](https://cloud.githubusercontent.com/assets/15215309/10772221/f16cc3e4-7cc2-11e5-9eba-902b61c3eea8.png)

When I did complete the koans, there was an error message saying "include_class is deprecated. Use java_import." This is an unrelated bug which I will fix in another pull request.  When I fixed this issue, I was confused, because the end screen made no hint (even in a zen way) that I was done -- I was convinced that there must be another hidden error.  

This pull request prevents the end screen from displaying on SyntaxErrors and other exceptions.  It also adds a message making clear that "You have completed the path".