### PR TITLE
test_constants_become_symbols is confusing

### DIFF
--- a/src/about_symbols.rb
+++ b/src/about_symbols.rb
@@ -35,7 +35,7 @@ class AboutSymbols < Neo::Koan
 
   in_ruby_version("mri") do
     RubyConstant = "What is the sound of one hand clapping?"
-    def test_constants_become_symbols
+    def test_constant_names_become_symbols
       all_symbols_as_strings = Symbol.all_symbols.map { |x| x.to_s }
 
       assert_equal __(true), all_symbols_as_strings.include?(__("RubyConstant"))


### PR DESCRIPTION
@GameKyuubi and I think that, similarly to the previous test
`test_method_names_become_symbol`, the test should be named
`test_constant_names_become_symbols`, especially as in this test, the constant
is a String, one could expect to find "What is the sound of one hand clapping?"
in `all_symbols_as_strings`.